### PR TITLE
Feat/allow group search

### DIFF
--- a/fastauth.go
+++ b/fastauth.go
@@ -428,7 +428,7 @@ func signup(w http.ResponseWriter, r *http.Request) {
 
 	refreshToken := base32.StdEncoding.EncodeToString(rnd[32:48])
 
-	err = insertUser(salt, cred.Email, dk, emailToken, refreshToken)
+	err = insertUser(salt, cred.Email, dk, "USR", emailToken, refreshToken)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "invalid_request", "blocked", "ERR-signup-06, insert user failed: %v", err)
 		return

--- a/fastauth_test.go
+++ b/fastauth_test.go
@@ -389,6 +389,17 @@ func TestSecret(t *testing.T) {
 	assert.Equal(t, "n4bQgYhMfWWaL-qgxVrQFaO_TxsrC4Is0V1sFbDwCgg", s)
 }
 
+func TestGetAttrDN(t *testing.T) {
+
+	assert.Equal(t,
+		getAttrDN("CN=tom,OU=P_Internal,OU=P_Users,DC=test,DC=ch", "cn"),
+		"tom")
+
+	assert.Equal(t,
+		getAttrDN("CN=tom,OU=P_Internal,OU=P_Users,DC=test,DC=ch", "cn"),
+		getAttrDN("cn=tom,ou=P_Internal,ou=P_Users,dc=test,dc=ch", "CN"))
+}
+
 func mainTest(opts *Opts) func() {
 	defaultOpts(opts)
 	options = opts

--- a/ldap.go
+++ b/ldap.go
@@ -82,21 +82,17 @@ func handleSearch(w ldap.ResponseWriter, m *ldap.Message) {
 		return
 	}
 
-	_, err := dbSelect(cn)
+	dbRes, err := dbSelect(cn)
 	if err != nil {
 		res := ldap.NewSearchResultDoneResponse(ldap.LDAPResultUnwillingToPerform)
 		w.Write(res)
 		return
 	}
 
-	var e message.SearchResultEntry
-	if strings.Index(string(r.BaseObject()), "cn") >= 0 {
-		e = ldap.NewSearchResultEntry(string(r.BaseObject()))
-		w.Write(e)
-	} else {
-		e = ldap.NewSearchResultEntry("cn=" + cn + ", " + string(r.BaseObject()))
-		w.Write(e)
-	}
+	e := ldap.NewSearchResultEntry("cn=" + cn + ", " + string(r.BaseObject()))
+	e.AddAttribute("cn", message.AttributeValue(string(dbRes.role)))
+	w.Write(e)
+
 	res := ldap.NewSearchResultDoneResponse(ldap.LDAPResultSuccess)
 	w.Write(res)
 }

--- a/ldap.go
+++ b/ldap.go
@@ -46,7 +46,7 @@ func getAttrDN(dn string, atyp string) string {
 	for _, rdn := range parsedDN.RDNs {
 		for _, rdnAttr := range rdn.Attributes {
 			log.Printf("found attr %v", rdnAttr.Type)
-			if rdnAttr.Type == atyp {
+			if strings.ToLower(rdnAttr.Type) == strings.ToLower(atyp) {
 				return rdnAttr.Value
 			}
 		}


### PR DESCRIPTION
- role in the db is dynamic
- role is definable with args during startup like username:pw:role but **username:pw is still possible**
- LDAP getAttrDN is caseinsensitve
- the role is returned in an attribute when a searchrequest is done in LDAP